### PR TITLE
Migrate to Snakemake 9 and the panoptes logger plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,11 @@ jobs:
             --cores 1 \
             -n
 
-      - name: Lint the Snakefile
+      - name: Lint the Snakefile (informational)
+        # snakemake --lint exits non-zero on style hits (e.g. merge_results
+        # has no conda env). The hits are real but not blocking, so keep the
+        # step informational rather than failing the build.
+        continue-on-error: true
         run: |
           snakemake \
             --snakefile Snakefile \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,7 @@ jobs:
             --cores 1 \
             -n
 
-      - name: Lint the Snakefile (informational)
-        # snakemake --lint exits non-zero on style hits (e.g. merge_results
-        # has no conda env). The hits are real but not blocking, so keep the
-        # step informational rather than failing the build.
-        continue-on-error: true
+      - name: Lint the Snakefile
         run: |
           snakemake \
             --snakefile Snakefile \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Snakemake 9
+        run: pip install 'snakemake>=9'
+
+      - name: Dry-run the workflow (Snakefile + DAG resolve)
+        run: |
+          snakemake \
+            --snakefile Snakefile \
+            --configfile config.yaml \
+            --cores 1 \
+            -n
+
+      - name: Lint the Snakefile
+        run: |
+          snakemake \
+            --snakefile Snakefile \
+            --configfile config.yaml \
+            --lint

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .*
 !.gitignore
+!.github
 results
 logs
 dag.png

--- a/README.md
+++ b/README.md
@@ -1,47 +1,82 @@
 # Info
 
-Snakemake example workflow to test [panoptes](https://github.com/panoptes-organization/panoptes)
+Snakemake example workflow to test [panoptes](https://github.com/panoptes-organization/panoptes).
+
+This workflow targets **Snakemake 9**. Snakemake 9 removed the legacy
+`--wms-monitor` flag, so monitoring is now wired up through the
+[`snakemake-logger-plugin-panoptes`](https://github.com/panoptes-organization/snakemake-logger-plugin-panoptes)
+logger plugin.
+
+## What it does
+
+Runs a small four-sample reference pipeline against the included chr14 GTF
+and BAM data:
+
+| Rule | What it does |
+| --- | --- |
+| `samtools_sort` | Sort the input BAM per sample |
+| `samtools_index` | Build the `.bai` index for each sorted BAM |
+| `HTSeq_count` | Count reads per gene with HTSeq |
+| `merge_results` | Paste the per-sample count tables into one matrix |
+
+All 14 jobs (4 samples × 3 per-sample rules + 1 merge + 1 finish) and the
+overall workflow status are streamed to panoptes in real time via
+`--logger panoptes`.
 
 # Installation
 
-The workflow relies on conda dependencies to run, so we recommend to first install miniconda. You can find instructions here:
-
+The workflow relies on conda dependencies to run, so we recommend installing
+miniconda first. Instructions:
 https://docs.conda.io/en/latest/miniconda.html
 
+Install Snakemake 9 and the panoptes logger plugin. With conda (recommended,
+since the example workflow rules use conda envs anyway):
 
-Then you need to install a custom snakemake in a virtual environment. The following instructions are based on virtualenv and pip.
 ```bash
-# clone snakemake
-git clone https://github.com/snakemake/snakemake
-cd snakemake
-# create a virtual environment
-virtualenv -p `which python3` venv_snakemake_develop
-# activate
-source venv_snakemake_develop/bin/activate
-# install
-pip install .
-cd ..
-# clone snakemake example workflow
+conda create -n panoptes-example -c conda-forge -c bioconda \
+    'snakemake>=9' snakemake-logger-plugin-panoptes
+conda activate panoptes-example
+```
+
+Or with pip in a virtual environment:
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install 'snakemake>=9' snakemake-logger-plugin-panoptes
+```
+
+Then clone this example workflow:
+
+```bash
 git clone https://github.com/panoptes-organization/snakemake_example_workflow.git
+cd snakemake_example_workflow
 ```
 
 # Run workflow
 
-Activate the virtual environment with snakemake (in case it's not activated) and enter the snakemake example workflow directory
-```bash
-source snakemake/venv_snakemake_develop/bin/activate # run this if the virtual environment is not active
-cd snakemake_example_workflow
-```
+Start a panoptes server (see the [panoptes README](https://github.com/panoptes-organization/panoptes#run-the-server))
+so it is listening on `http://127.0.0.1:5000`, then:
 
-Create the dag
+Create the DAG:
 
 ```bash
 bash create_dag.sh
 ```
 
-Run workflow
+Run the workflow:
+
 ```bash
 bash run_local.sh
 ```
 
-**Note**: Make sure that the correct IP and port via --wms-monitor is specified in the run_local.sh script
+The workflow events are forwarded to panoptes by the
+`--logger panoptes` plugin specified in `run_local.sh`. To point at a
+panoptes server on a different host or port, edit the
+`--logger-panoptes-address` value in `run_local.sh` (or override it via the
+`SNAKEMAKE_LOGGER_PANOPTES_ADDRESS` environment variable).
+
+See the
+[`snakemake-logger-plugin-panoptes` README](https://github.com/panoptes-organization/snakemake-logger-plugin-panoptes)
+for the full list of plugin settings and how it maps Snakemake events to
+panoptes' API.

--- a/README.md
+++ b/README.md
@@ -33,10 +33,13 @@ Install Snakemake 9 and the panoptes logger plugin. With conda (recommended,
 since the example workflow rules use conda envs anyway):
 
 ```bash
-conda create -n panoptes-example -c conda-forge -c bioconda \
-    'snakemake>=9' snakemake-logger-plugin-panoptes
+conda create -n panoptes-example -c conda-forge -c bioconda 'snakemake>=9'
 conda activate panoptes-example
+pip install snakemake-logger-plugin-panoptes
 ```
+
+> A bioconda recipe for `snakemake-logger-plugin-panoptes` is on the way;
+> once it lands you can install it via conda instead of pip.
 
 Or with pip in a virtual environment:
 

--- a/Snakefile
+++ b/Snakefile
@@ -64,6 +64,8 @@ rule merge_results:
         counts=expand(os.path.join(config["output_dir"], "{sample}.htseq.tsv"), sample=config["samples"])
     output:
         counts=os.path.join(config["output_dir"], "counts.htseq.merged.tsv")
+    conda:
+        "envs/coreutils.yaml"
     threads:    1
     log:
         os.path.join(config["local_log"], "merge_results.log")

--- a/create_dag.sh
+++ b/create_dag.sh
@@ -1,4 +1,4 @@
-#!/urs/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/envs/coreutils.yaml
+++ b/envs/coreutils.yaml
@@ -1,0 +1,7 @@
+---
+channels:
+  - conda-forge
+dependencies:
+  - coreutils
+  - grep
+...

--- a/envs/htseq.yaml
+++ b/envs/htseq.yaml
@@ -3,5 +3,5 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - htseq=0.11.2
+  - htseq=2.0.5
 ...

--- a/run_local.sh
+++ b/run_local.sh
@@ -1,4 +1,4 @@
-#!/urs/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
@@ -12,4 +12,5 @@ snakemake \
 --local-cores 2 \
 --cores 2 \
 --rerun-incomplete \
---wms-monitor "http://127.0.0.1:5000"
+--logger panoptes \
+--logger-panoptes-address "http://127.0.0.1:5000"


### PR DESCRIPTION
## Summary

- **`run_local.sh`**: replaces `--wms-monitor` (removed in Snakemake 9) with `--logger panoptes --logger-panoptes-address http://127.0.0.1:5000` from the new [`snakemake-logger-plugin-panoptes`](https://github.com/panoptes-organization/snakemake-logger-plugin-panoptes) plugin. Shebang typo (`#!/urs/bin/bash`) fixed.
- **`create_dag.sh`**: same shebang typo fix.
- **`envs/htseq.yaml`**: bump `htseq=0.11.2` → `2.0.5`. The 2019 pin was broken on modern conda installs by a `pkg_resources`/`cython` regression (`DistributionNotFound: cython required by pysam`); 2.0.5 is the current stable bioconda build and works on both Linux x86_64 and Apple Silicon.
- **`envs/coreutils.yaml`** + **`Snakefile`**: give `merge_results` a conda env (`coreutils` + `grep`) so `snakemake --lint` reports the workflow clean.
- **`README.md`**: rewritten install (conda + pip), added a "What it does" table describing the 4-rule reference pipeline, cross-link to the plugin README for full settings reference.
- **`.github/workflows/ci.yml`**: new CI that dry-runs the workflow and lints the Snakefile on every push / PR. No panoptes server or rule execution — the panoptes repo's own CI exercises the end-to-end integration.

## Test plan

- [x] `snakemake -n` resolves the DAG (14 jobs).
- [x] `snakemake --lint` exits clean ("workflow is in a good condition").
- [x] Local end-to-end run against panoptes 0.2.3 + plugin 0.1.1: workflow finishes `14 of 14 steps (100%) done`, panoptes records `status=Done`, `jobs_done=14`, `jobs_total=14`.
- [x] CI green on `snakemake-9-logger-plugin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)