### PR TITLE
README: install the logger plugin from bioconda

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,9 @@ Install Snakemake 9 and the panoptes logger plugin. With conda (recommended,
 since the example workflow rules use conda envs anyway):
 
 ```bash
-conda create -n panoptes-example -c conda-forge -c bioconda 'snakemake>=9'
+conda create -n panoptes-example -c conda-forge -c bioconda 'snakemake>=9' snakemake-logger-plugin-panoptes
 conda activate panoptes-example
-pip install snakemake-logger-plugin-panoptes
 ```
-
-> A bioconda recipe for `snakemake-logger-plugin-panoptes` is on the way;
-> once it lands you can install it via conda instead of pip.
 
 Or with pip in a virtual environment:
 


### PR DESCRIPTION
## Summary
- `snakemake-logger-plugin-panoptes` is now published on the bioconda channel (bioconda/bioconda-recipes#65627 merged).
- The conda install path now pulls the plugin from bioconda alongside Snakemake, instead of installing Snakemake via conda and the plugin via pip.
- Drops the "a bioconda recipe is on the way" note.

## Test plan
- [x] `conda install -c conda-forge -c bioconda snakemake-logger-plugin-panoptes` resolves (verified against the merged artifact).
- [ ] Docs-only change; no workflow behavior affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)